### PR TITLE
Fix build errors with tito

### DIFF
--- a/containers/server-saline-image/server-saline-image.changes
+++ b/containers/server-saline-image/server-saline-image.changes
@@ -1,4 +1,1 @@
--------------------------------------------------------------------
-Tue Dec  3 09:00:23 UTC 2024 - Victor Zhestkov <vzhestkov@suse.com>
-
 - Initial version

--- a/containers/server-saline-image/tito.props
+++ b/containers/server-saline-image/tito.props
@@ -1,0 +1,3 @@
+[buildconfig]
+tagger = tito.tagger.SUSEContainerTagger
+builder = custom.ContainerBuilder


### PR DESCRIPTION
## What does this PR change?

@vzhestkov we need a `tito.props` file for the automatic build done by the push-to-obs script.
For the same reason, given that this is a new container, we need to provide also the master `.changes`, but without any header, or the automation is not going to add the faketagger info until we don't tag for submitting to maintenance.

You can see the automatic push to OBS here in my project: https://build.opensuse.org/package/show/home:deneb_alpha:test_saline/server-saline-image

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: new image

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
